### PR TITLE
Wrap DEBUG_ISR_STACK_USAGE in an ifndef

### DIFF
--- a/mbed_memory_status.c
+++ b/mbed_memory_status.c
@@ -32,7 +32,9 @@
 #include "platform/critical.h"
 #include "platform/mbed_stats.h"
 
+#ifndef DEBUG_ISR_STACK_USAGE
 #define DEBUG_ISR_STACK_USAGE  0
+#endif
 #define DEBUG_MEMORY_CONTENTS  0
 
 #define OUTPUT_SERIAL          1

--- a/mbed_memory_status.c
+++ b/mbed_memory_status.c
@@ -35,7 +35,9 @@
 #ifndef DEBUG_ISR_STACK_USAGE
 #define DEBUG_ISR_STACK_USAGE  0
 #endif
+#ifndef DEBUG_MEMORY_CONTENTS
 #define DEBUG_MEMORY_CONTENTS  0
+#endif
 
 #define OUTPUT_SERIAL          1
 #define OUTPUT_RTT             0


### PR DESCRIPTION
So the macro can be declared in mbed_app.json. Currently it's being overwritten.